### PR TITLE
Memory allocation discordance fixed

### DIFF
--- a/kernel/src/driver/bfs.c
+++ b/kernel/src/driver/bfs.c
@@ -2,7 +2,7 @@
 #include <util/event.h>
 #include "bfs.h"
 #include "string.h"
-#include "../gmalloc.h"
+#include "../malloc.h"
 #include "../cpu.h"
 
 typedef struct {
@@ -65,7 +65,7 @@ typedef struct {
 static int bfs_mount(FileSystemDriver* fs_driver, DiskDriver* disk_driver, uint32_t lba, size_t size) {
 	// Size of loader is now about 60kB. Investigate til 200kB (50 Clusters)
 	BFSSuperBlock* sb;
-	void* temp = gmalloc(FS_BLOCK_SIZE);
+	void* temp = malloc(FS_BLOCK_SIZE);
 	if(disk_driver->read(disk_driver, lba, 8, temp) > 0) {
 		sb = (BFSSuperBlock*)temp;
 		if(sb->magic == BFS_MAGIC) {
@@ -123,15 +123,15 @@ static BFSInode* get_inode_entry(FileSystemDriver* driver, uint32_t idx) {
 	// NOTE: Assume that inode table is smaller than one cluster
 	void* temp = cache_get(driver->cache, (void*)(uintptr_t)(priv->link_table_addr));
 	if(!temp) {
-		temp = gmalloc(FS_BLOCK_SIZE);
+		temp = malloc(FS_BLOCK_SIZE);
 		if(disk_driver->read(disk_driver, priv->link_table_addr, FS_SECTOR_PER_BLOCK, temp) <= 0) {
 			printf("Reading root directory failed\n");
-			gfree(temp);
+			free(temp);
 			return NULL;
 		}
 		if(!cache_set(driver->cache, (void*)(uintptr_t)(priv->link_table_addr), temp)) {
 			printf("cache setting error\n");
-			gfree(temp);
+			free(temp);
 			return NULL;
 		}
 	}
@@ -160,15 +160,15 @@ static int find_directory_entry(FileSystemDriver* driver, const char* name, BFSF
 	// NOTE: Assume that root directory is smaller than one cluster
 	void* temp = cache_get(driver->cache, (void*)(uintptr_t)(priv->data_addr));
 	if(!temp) {
-		temp = gmalloc(FS_BLOCK_SIZE);
+		temp = malloc(FS_BLOCK_SIZE);
 		if(disk_driver->read(disk_driver, priv->data_addr, FS_SECTOR_PER_BLOCK, temp) <= 0) {
 			printf("Reading root directory failed\n");
-			gfree(temp);
+			free(temp);
 			return -1;
 		}
 		if(!cache_set(driver->cache, (void*)(uintptr_t)(priv->data_addr), temp)) {
 			printf("cache setting error\n");
-			gfree(temp);
+			free(temp);
 			return -2;
 		}
 	}
@@ -287,13 +287,13 @@ static int bfs_read(FileSystemDriver* driver, void* _file, void* buffer, size_t 
 
 			if(disk_driver->read(disk_driver, sector, FS_SECTOR_PER_BLOCK, read_buf) <= 0) {
 				printf("read error\n");
-				gfree(read_buf);
+				free(read_buf);
 				return -2;
 			}
 
 			if(!cache_set(driver->cache, (void*)(uintptr_t)sector, read_buf)) {
 				printf("cache setting error\n");
-				gfree(read_buf);
+				free(read_buf);
 				return -3;
 			}
 		}
@@ -508,15 +508,15 @@ static void* bfs_opendir(FileSystemDriver* driver, const char* dir_name) {
 	// NOTE: Assume that root directory is smaller than one cluster
 	void* temp = cache_get(driver->cache, (void*)(uintptr_t)(priv->data_addr));
 	if(!temp) {
-		temp = gmalloc(FS_BLOCK_SIZE);
+		temp = malloc(FS_BLOCK_SIZE);
 		if(disk_driver->read(disk_driver, priv->data_addr, FS_SECTOR_PER_BLOCK, temp) <= 0) {
 			printf("Reading root directory failed\n");
-			gfree(temp);
+			free(temp);
 			return NULL;
 		}
 		if(!cache_set(driver->cache, (void*)(uintptr_t)(priv->data_addr), temp)) {
 			printf("cache setting error\n");
-			gfree(temp);
+			free(temp);
 			return NULL;
 		}
 	}

--- a/kernel/src/driver/fs.c
+++ b/kernel/src/driver/fs.c
@@ -4,7 +4,6 @@
 #include "disk.h"
 #include "../cpu.h"
 #include <malloc.h>
-#include <gmalloc.h>
 #include <util/cache.h>
 #include <util/event.h>
 
@@ -52,7 +51,7 @@ int fs_mount(uint32_t disk, uint8_t partition, int type, const char* path) {
 	}
 
 	// Cache size is (FS_CACHE_BLOCK * FS_BLOCK_SIZE(normally 4K))
-	Cache* cache = cache_create(FS_CACHE_BLOCK, gfree, NULL); 
+	Cache* cache = cache_create(FS_CACHE_BLOCK, free, NULL); 
 	if(!cache) {
 		printf("Create cache fail\n");
 		return -3;

--- a/kernel/src/driver/virtio_blk.c
+++ b/kernel/src/driver/virtio_blk.c
@@ -11,6 +11,7 @@
 #include "../port.h"
 #include "../cpu.h"
 #include "../pci.h"
+#include "../page.h"
 
 // Virtio driver header
 #include "virtio_ring.h"
@@ -130,7 +131,7 @@ static VirtIOBlkReq* buf_to_req(void* buffer, uint32_t type, uint32_t sector, in
 	VirtIOBlkReq* req = gmalloc(sizeof(VirtIOBlkReq));
 	req->type = type;
 	req->status = 0xff;
-	req->data = buffer;
+	req->data = (void*)VIRTUAL_TO_PHYSICAL((uintptr_t)buffer);
 	req->sector = sector;
 	req->sector_count = sector_count;
 	return req;

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -82,7 +82,7 @@ expat/libexpat.a:
 	cd expat; make
 	cd expat; make install
 
-libexpat.a: expat/libexpat.a
+libexpat.a: expat/lib/libexpat.a
 	cp expat/lib/libexpat.a .
 	mkdir -p ../sdk/include
 	cp -rL expat/include/* ../sdk/include


### PR DESCRIPTION
No more global malloc in filesystem. VirtI/O block disk driver changed to use buffer that translated to phsyical memory even when it received virtual memory buffer.