### PR TITLE
icc_init bug has been fixed & Core id is changed into Apic id

### DIFF
--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -230,11 +230,11 @@ static uint16_t slp_typa;
 static uint16_t slp_typb;
 
 void acpi_init() {
-	uint8_t core_id = mp_core_id();
+	uint8_t apic_id = mp_apic_id();
 	
 	rsdp = find_RSDP();
 	if(!rsdp) {
-		if(core_id == 0) {
+		if(apic_id == 0) {
 			//printf("\tCannot find root system description pointer\n");
 			while(1) asm("hlt");
 		}

--- a/kernel/src/gmalloc.c
+++ b/kernel/src/gmalloc.c
@@ -85,7 +85,7 @@ void gmalloc_init(uintptr_t ramdisk_addr, uint32_t ramdisk_size) {
 	
 	uint8_t* core_map = mp_core_map();
 	for(int i = 0; i < MP_MAX_CORE_COUNT; i++) {
-		if(!core_map[i])
+		if(core_map[i] == MP_CORE_INVALID)
 			continue;
 		
 		reserved[reserved_count].start = 0x400000 + 0x200000 * i;

--- a/kernel/src/icc.h
+++ b/kernel/src/icc.h
@@ -22,7 +22,7 @@ typedef enum {
 typedef struct _ICC_Message {
 	uint32_t	id;
 	uint8_t		type;
-	uint8_t		core_id;
+	uint8_t		apic_id;
 	int		result;
 	
 	union {
@@ -56,7 +56,7 @@ extern ICC_Message* icc_msg;	// Core's local message
 void icc_init();
 ICC_Message* icc_alloc(uint8_t type);
 void icc_free(ICC_Message* msg);
-uint32_t icc_send(ICC_Message* msg, uint8_t core_id);
+uint32_t icc_send(ICC_Message* msg, uint8_t apic_id);
 void icc_register(uint8_t type, void(*event)(ICC_Message*));
 
 #endif /* __ICC_H__ */

--- a/kernel/src/loader.c
+++ b/kernel/src/loader.c
@@ -97,7 +97,7 @@ static bool check_header(void* addr) {
 static uint32_t load(VM* vm, void** malloc_pool, void** gmalloc_pool) {
 	int thread_id = 0;
 	for(int i = 0; i < MP_MAX_CORE_COUNT; i++) {
-		if(vm->cores[i] == mp_core_id()) {
+		if(vm->cores[i] == mp_apic_id()) {
 			thread_id = i;
 			break;
 		}
@@ -352,7 +352,7 @@ static void load_symbols(VM* vm, uint32_t task_id) {
 static bool relocate(VM* vm, void* malloc_pool, void* gmalloc_pool, uint32_t task_id) {
 	int thread_id = 0;
 	for(int i = 0; i < MP_MAX_CORE_COUNT; i++) {
-		if(vm->cores[i] == mp_core_id()) {
+		if(vm->cores[i] == mp_apic_id()) {
 			thread_id = i;
 			break;
 		}

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -246,7 +246,7 @@ static void icc_start(ICC_Message* msg) {
 		ICC_Message* msg2 = icc_alloc(ICC_TYPE_STARTED);
 
 		msg2->result = errno;	// errno from loader_load
-		icc_send(msg2, msg->core_id);
+		icc_send(msg2, msg->apic_id);
 		icc_free(msg);
 		printf("Execution FAILED: %x\n", errno);
 		return;
@@ -275,7 +275,7 @@ static void icc_start(ICC_Message* msg) {
 	msg2->data.started.stderr_tail = (void*)TRANSLATE_TO_PHYSICAL((uint64_t)task_addr(id, SYM_STDERR_TAIL));
 	msg2->data.started.stderr_size = *(int*)task_addr(id, SYM_STDERR_SIZE);
 	
-	icc_send(msg2, msg->core_id);
+	icc_send(msg2, msg->apic_id);
 
 	icc_free(msg);
 	
@@ -286,7 +286,7 @@ static void icc_resume(ICC_Message* msg) {
 	if(msg->result < 0) {
 		ICC_Message* msg2 = icc_alloc(ICC_TYPE_RESUMED);
 		msg2->result = msg->result;
-		icc_send(msg2, msg->core_id);
+		icc_send(msg2, msg->apic_id);
 
 		icc_free(msg);
 		return;
@@ -295,7 +295,7 @@ static void icc_resume(ICC_Message* msg) {
 	printf("Resuming VM...\n");
 	ICC_Message* msg2 = icc_alloc(ICC_TYPE_RESUMED);
 
-	icc_send(msg2, msg->core_id);
+	icc_send(msg2, msg->apic_id);
 	icc_free(msg);
 	context_switch();
 }
@@ -310,7 +310,7 @@ static void icc_stop(ICC_Message* msg) {
 	if(msg->result < 0) { //Not yet core is started.
 		ICC_Message* msg2 = icc_alloc(ICC_TYPE_STOPPED);
 		msg2->result = msg->result;
-		icc_send(msg2, msg->core_id);
+		icc_send(msg2, msg->apic_id);
 
 		icc_free(msg);
 		return;

--- a/kernel/src/mp.h
+++ b/kernel/src/mp.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 
 #define MP_MAX_CORE_COUNT	16
+#define MP_CORE_INVALID		255
+
 #define MP_CORE(ptr, id)        (void*)((uint64_t)(ptr) + id * 0x200000)
 
 typedef struct {
@@ -120,8 +122,8 @@ uint8_t mp_cores[MP_MAX_CORE_COUNT];
 void mp_init();
 uint8_t mp_apic_id();
 uint8_t mp_core_id();
+uint8_t mp_apic_id_to_core_id(uint8_t apic_id);
 uint8_t mp_core_count();
-uint8_t mp_core_id_to_apic_id(uint8_t core_id);
 void mp_sync();
 void mp_parse_fps(MP_Parser* parser, void* context);
 uint8_t* mp_core_map();


### PR DESCRIPTION
* Core id is only used to show the user by mp_apic_id_to_core_id
* If apic is availble, mp_cores[apic_id] has it's 'core id' and if not, mp_cores[apic_id] is set as MP_CORE_INVALID
* Even cores in vm.c is initialized according to mp_cores order