### PR TITLE
A function get_dir_name is added in opendir

### DIFF
--- a/kernel/src/file.c
+++ b/kernel/src/file.c
@@ -265,20 +265,28 @@ off_t lseek(int fd, off_t offset, int whence) {
 }
 
 int opendir(const char* dir_name) {
-	File* dir = alloc_descriptor();
-
-	if(dir == NULL)
+	// Check whether format of the path is valid
+	if(dir_name[0] != '/')
 		return -1;
 
+	File* dir = alloc_descriptor();
+	if(dir == NULL)
+		return -2;
+	
 	dir->driver = fs_driver(dir_name);
 	if(!dir->driver) {
 		free_descriptor(dir);
-		return -2;
+		return -3;
 	}
 
-	dir->priv = dir->driver->opendir(dir->driver, dir_name);
+	const char* get_dir_name(const char* path) {
+		char* base = strchr(path + 1, '/');
+		return base ? base : "/";
+	}
+
+	dir->priv = dir->driver->opendir(dir->driver, get_dir_name(dir_name));
 	if(!dir->priv) 
-		return -3;
+		return -4;
 	
 	dir->type = FILE_TYPE_DIR;
 

--- a/kernel/src/file.c
+++ b/kernel/src/file.c
@@ -69,8 +69,8 @@ int open(const char* path, char* flags) {
 	}
 
 	const char* get_file_name(const char* path) {
-		char* base = strrchr(path, '/');
-		return base ? base + 1 : path;
+		char* base = strchr(path + 1, '/');
+		return base ? base + 1 : "/";
 	}
 
 	ret = file->driver->open(file->driver, get_file_name(path), flags, &file->priv);

--- a/lib/core/include/file.h
+++ b/lib/core/include/file.h
@@ -35,7 +35,7 @@ int file_close(int fd, void(*callback)(int ret, void* context), void* context);
  * Asynchronous read from a file descriptor
  */
 int file_read(int fd, void* buffer, size_t size,
-	     void(*callback)(void* buffer, size_t size, void* context),
+	     void(*callback)(void* buffer, int size, void* context),
 	     void* context);
 
 /**

--- a/lib/core/src/file.c
+++ b/lib/core/src/file.c
@@ -160,7 +160,7 @@ out:
 	return ret;
 }
 
-int file_read(int fd, void* buffer, size_t size, void(*callback)(void* buffer, size_t size, void* context), void* context) {
+int file_read(int fd, void* buffer, size_t size, void(*callback)(void* buffer, int size, void* context), void* context) {
 	int ret = FIO_OK;
 	if(fd < 0) {
 		ret = -FIO_ERR_BADFD;


### PR DESCRIPTION
* It removes the mounting point from argument dir_name.
  Because filesystem doesn't know anything about the mounting point.