### PR TITLE
The way to remove the mounting point is modified

### DIFF
--- a/kernel/src/driver/fs.c
+++ b/kernel/src/driver/fs.c
@@ -83,7 +83,7 @@ int fs_mount(uint32_t disk, uint8_t partition, int type, const char* path) {
 	return 0;
 }
 
-FileSystemDriver* fs_driver(const char* path) {
+FileSystemDriver* fs_driver(const char* path, char** prefix) {
 	int len = 0;
 	char* path_prefix = "";
 	MapIterator iter;
@@ -101,11 +101,14 @@ FileSystemDriver* fs_driver(const char* path) {
 
 	}
 
+	*prefix = path_prefix;
+
 	return map_get(mounts, (void*)path_prefix);
 }
 
 int fs_umount(const char* path) {
-	FileSystemDriver* driver = fs_driver(path);
+	char* path_prefix;
+	FileSystemDriver* driver = fs_driver(path, &path_prefix);
 
 	if(!driver) 
 		return -2; // Reuqired file system not found
@@ -113,7 +116,7 @@ int fs_umount(const char* path) {
 	if(driver->umount(driver) < 0)
 		return -3; // Memory free error
 
-	map_remove(mounts, (void*)path);
+	map_remove(mounts, (void*)path_prefix);
 
 	return 0;
 }

--- a/kernel/src/driver/fs.h
+++ b/kernel/src/driver/fs.h
@@ -80,7 +80,7 @@ int fs_write_async(File* file, void* buffer, size_t size, void(*callback)(void* 
 int fs_mount(uint32_t disk, uint8_t partition, int type, const char* path);
 int fs_umount(const char* path);
 bool fs_register(FileSystemDriver* driver);
-FileSystemDriver* fs_driver(const char* path);
+FileSystemDriver* fs_driver(const char* path, char** prefix);
 
 /**
  * High level disk I/O function which uses disk cache

--- a/kernel/src/file.c
+++ b/kernel/src/file.c
@@ -62,15 +62,18 @@ int open(const char* path, char* flags) {
 		goto failed;
 	}
 
-	file->driver = fs_driver(path);
+	char* path_prefix;
+	file->driver = fs_driver(path, &path_prefix);
 	if(!file->driver) {
 		ret = -5;
 		goto failed;
 	}
 
+	path += strlen(path_prefix);
+
 	const char* get_file_name(const char* path) {
-		char* base = strchr(path + 1, '/');
-		return base ? base + 1 : "/";
+		char* base = strchr(path, '/');
+		return base ? base + 1 : path;
 	}
 
 	ret = file->driver->open(file->driver, get_file_name(path), flags, &file->priv);
@@ -272,19 +275,17 @@ int opendir(const char* dir_name) {
 	File* dir = alloc_descriptor();
 	if(dir == NULL)
 		return -2;
-	
-	dir->driver = fs_driver(dir_name);
+
+	char* path_prefix;	
+	dir->driver = fs_driver(dir_name, &path_prefix);
 	if(!dir->driver) {
 		free_descriptor(dir);
 		return -3;
 	}
 
-	const char* get_dir_name(const char* path) {
-		char* base = strchr(path + 1, '/');
-		return base ? base : "/";
-	}
+	dir_name += strlen(path_prefix);
 
-	dir->priv = dir->driver->opendir(dir->driver, get_dir_name(dir_name));
+	dir->priv = dir->driver->opendir(dir->driver, dir_name);
 	if(!dir->priv) 
 		return -4;
 	


### PR DESCRIPTION
* There was a bug when it uses '/' to figure out where is the mounting point.
  So I fixed fs_driver API to hand over path_prefix which is the mounting point of filesystem.