### PR TITLE
Dummy write function is added in usbclient.c

### DIFF
--- a/kernel/src/driver/usb/usbclient.c
+++ b/kernel/src/driver/usb/usbclient.c
@@ -120,10 +120,16 @@ static int usb_msc_read(DiskDriver* driver, uint32_t lba, int sector_count, unsi
 	return result;
 }
 
+static int usb_msc_write(DiskDriver* driver, uint32_t lba, int sector_count, unsigned char* buf) {
+	// It's not been implemented yet
+	return -1;
+}
+
 DiskDriver usb_msc_driver = {
 	.type = DISK_TYPE_USB,
 	.init = usb_client_init,
 	.read = usb_msc_read,
+	.write = usb_msc_write,
 };
 
 #endif


### PR DESCRIPTION
* It prevents from killing the kernel from user side.