### PR TITLE
Tool for test framework added

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,8 @@
 	path = tools/grub 
 	url = git://git.savannah.gnu.org/grub.git 
 	ignore = dirty
+
+[submodule "cmocka"]
+	path = cmocka
+	url = git://git.cryptomilk.org/projects/cmocka.git
+	ignore = dirty


### PR DESCRIPTION
* Cmocka submodule added. It's for testing. Test sources link this
library.
* Cmocka library install instructions below.
    $ cd rtos/tools/cmocka
    $ mkdir build
    $ mv build && cmake -DMAKE_INSTALL_PREFIX=/usr
    $ make & sudo make install