### PR TITLE
Reserved Memory area is added to rserved map

### DIFF
--- a/kernel/src/gmalloc.c
+++ b/kernel/src/gmalloc.c
@@ -69,8 +69,12 @@ void gmalloc_init(uintptr_t ramdisk_addr, uint32_t ramdisk_size) {
 		uintptr_t end;
 	} Block;
 	
-	Block reserved[3 + MP_MAX_CORE_COUNT];
+	Block reserved[4 + MP_MAX_CORE_COUNT];
 	int reserved_count = 0;
+	reserved[reserved_count].start = 0x00;		// IVT & BDA
+	reserved[reserved_count].end = 0x4ff;
+	reserved_count++;
+
 	reserved[reserved_count].start = 0x100000;	// Description table
 	reserved[reserved_count].end = 0x200000;
 	reserved_count++;


### PR DESCRIPTION
* Between 0x00 and 0x04ff area is unusable sapce.
* This area exists for IVT and BDA.