### PR TITLE
PacketNgin standard C library (string.c, malloc.c) rearranged

### DIFF
--- a/kernel/src/driver/virtio_blk.c
+++ b/kernel/src/driver/virtio_blk.c
@@ -4,7 +4,6 @@
 // PacketNgin kernel header
 #include <util/list.h>
 #include <util/event.h>
-#include <tlsf.h>
 #include "disk.h"
 #include "../file.h"
 #include "../gmalloc.h"

--- a/kernel/src/gmalloc.c
+++ b/kernel/src/gmalloc.c
@@ -1,14 +1,15 @@
 #include <stdio.h>
 #include <string.h>
-#include <tlsf.h>
 #include <util/list.h>
+#include <tlsf.h>
 #include <malloc.h>
+#include <_malloc.h>
+#include "malloc.h"
 #include "idt.h"
 #include "pnkc.h"
 #include "mp.h"
 #include "shared.h"
 #include "multiboot2.h"
-#include "malloc.h"
 #include "gmalloc.h"
 
 void* gmalloc_pool;

--- a/kernel/src/icc.c
+++ b/kernel/src/icc.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <util/event.h>
 #include <lock.h>
-#include <tlsf.h>
+#include <_malloc.h>
 #include <timer.h>
 #include "asm.h"
 #include "apic.h"
@@ -83,11 +83,11 @@ void icc_init() {
 		shared->icc_pool = fifo_create(icc_max, gmalloc_pool);
 
 		for(int i = 0; i < icc_max; i++) {
-			ICC_Message* icc_message = malloc_ex(sizeof(ICC_Message), shared->icc_pool->pool);
+			ICC_Message* icc_message = __malloc(sizeof(ICC_Message), shared->icc_pool->pool);
 			fifo_push(shared->icc_pool, icc_message);
 		}
 
-		shared->icc_queues = malloc_ex(MP_MAX_CORE_COUNT * sizeof(Icc), gmalloc_pool);
+		shared->icc_queues = __malloc(MP_MAX_CORE_COUNT * sizeof(Icc), gmalloc_pool);
 
 		uint8_t* core_map = mp_core_map();
 		for(int i = 0; i < MP_MAX_CORE_COUNT; i++) {

--- a/kernel/src/loader.c
+++ b/kernel/src/loader.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <tlsf.h>
+#include <_malloc.h>
 #include <util/list.h>
 #include <elf.h>
 #include <errno.h>
@@ -284,7 +285,7 @@ static bool load_args(VM* vm, void* malloc_pool, uint32_t task_id) {
 	
 	// Second try: Push to malloc area
 	if(malloc_pool) {
-		vaddr = malloc_ex(len, malloc_pool);
+		vaddr = __malloc(len, malloc_pool);
 		goto dump;
 	}
 	
@@ -365,7 +366,7 @@ static bool relocate(VM* vm, void* malloc_pool, void* gmalloc_pool, uint32_t tas
 	if(task_addr(task_id, SYM_MALLOC_POOL)) {
 		*(uint64_t*)task_addr(task_id, SYM_MALLOC_POOL) = (uint64_t)malloc_pool;
 		
-		void* __stdin = malloc_ex(4096, malloc_pool);
+		void* __stdin = __malloc(4096, malloc_pool);
 		if(__stdin) {
 			*(uint64_t*)task_addr(task_id, SYM_STDIN) = (uint64_t)__stdin;
 			*(size_t*)task_addr(task_id, SYM_STDIN_SIZE) = 4096;
@@ -374,7 +375,7 @@ static bool relocate(VM* vm, void* malloc_pool, void* gmalloc_pool, uint32_t tas
 			return false;
 		}
 		
-		void* __stdout = malloc_ex(4096, malloc_pool);
+		void* __stdout = __malloc(4096, malloc_pool);
 		if(__stdout) {
 			*(uint64_t*)task_addr(task_id, SYM_STDOUT) = (uint64_t)__stdout;
 			*(size_t*)task_addr(task_id, SYM_STDOUT_SIZE) = 4096;
@@ -383,7 +384,7 @@ static bool relocate(VM* vm, void* malloc_pool, void* gmalloc_pool, uint32_t tas
 			return false;
 		}
 		
-		void* __stderr = malloc_ex(4096, malloc_pool);
+		void* __stderr = __malloc(4096, malloc_pool);
 		if(__stderr) {
 			*(uint64_t*)task_addr(task_id, SYM_STDERR) = (uint64_t)__stderr;
 			*(size_t*)task_addr(task_id, SYM_STDERR_SIZE) = 4096;
@@ -397,9 +398,9 @@ static bool relocate(VM* vm, void* malloc_pool, void* gmalloc_pool, uint32_t tas
 		if(!vm->fio) {
 			user_fio = fio_create(gmalloc_pool);
 
-			vm->fio = malloc_ex(sizeof(VFIO), gmalloc_pool);
-			vm->fio->input_buffer = malloc_ex(sizeof(FIFO), gmalloc_pool);
-			vm->fio->output_buffer = malloc_ex(sizeof(FIFO), gmalloc_pool);
+			vm->fio = __malloc(sizeof(VFIO), gmalloc_pool);
+			vm->fio->input_buffer = __malloc(sizeof(FIFO), gmalloc_pool);
+			vm->fio->output_buffer = __malloc(sizeof(FIFO), gmalloc_pool);
 
 			vm->fio->input_buffer->head = 0;
 			vm->fio->input_buffer->tail = 0;

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -4,7 +4,7 @@
 #include <errno.h>
 
 // Core
-#include "util/event.h"
+#include <util/event.h>
 
 // Kernel
 #include "asm.h"
@@ -33,6 +33,7 @@
 #include "shell.h"
 #include "loader.h"
 #include "vfio.h"
+#include "shared.h"
 
 // Drivers
 #include "driver/pata.h"

--- a/kernel/src/malloc.c
+++ b/kernel/src/malloc.c
@@ -1,5 +1,6 @@
 #include <tlsf.h>
 #include <malloc.h>
+#include <_malloc.h>
 #include "stdio.h"
 #include "pnkc.h"
 #include "page.h"
@@ -142,7 +143,7 @@ void freed(void* ptr) {
 
 #if 0
 inline void* malloc(size_t size) {
-	void* ptr = malloc_ex(size, __malloc_pool);
+	void* ptr = __malloc(size, __malloc_pool);
 	
 	if(!ptr) {
 		// TODO: print to stderr
@@ -164,7 +165,7 @@ inline void* malloc(size_t size) {
 }
 
 inline void free(void* ptr) {
-	free_ex(ptr, __malloc_pool);
+	__free(ptr, __malloc_pool);
 	
 	#if DEBUG
 	freed(ptr);
@@ -172,7 +173,7 @@ inline void free(void* ptr) {
 }
 
 inline void* realloc(void* ptr, size_t size) {
-	void* ptr2 = realloc_ex(ptr, size, __malloc_pool);
+	void* ptr2 = __realloc(ptr, size, __malloc_pool);
 	#if DEBUG
 	freed(ptr);
 	malloced(((void**)read_rbp())[1], size, ptr2);
@@ -181,7 +182,7 @@ inline void* realloc(void* ptr, size_t size) {
 }
 
 inline void* calloc(size_t nmemb, size_t size) {
-	void* ptr = calloc_ex(nmemb, size, __malloc_pool);
+	void* ptr = __calloc(nmemb, size, __malloc_pool);
 	#if DEBUG
 	malloced(((void**)read_rbp())[1], nmemb * size, ptr);
 	#endif /* DEBUG */

--- a/kernel/src/shared.h
+++ b/kernel/src/shared.h
@@ -22,4 +22,6 @@ typedef struct {
 
 Shared* shared;
 
+void shared_init();
+
 #endif /* __SHARED_H__ */

--- a/kernel/src/string.c
+++ b/kernel/src/string.c
@@ -1,6 +1,4 @@
-#define DONT_MAKE_WRAPPER
 #include <_string.h>
-#undef DONT_MAKE_WRAPPER
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/kernel/src/vm.c
+++ b/kernel/src/vm.c
@@ -5,7 +5,6 @@
 #include <util/event.h>
 #include <util/ring.h>
 #include <net/md5.h>
-#include <tlsf.h>
 #include <timer.h>
 #include <file.h>
 #include "vm.h"

--- a/lib/core/include/_malloc.h
+++ b/lib/core/include/_malloc.h
@@ -1,46 +1,12 @@
+/* Wrapper of TLSF malloc */
 #ifndef ___MALLOC_H__
 #define ___MALLOC_H__
 
 #include <stddef.h>
 
-size_t __get_used_size(void *mem_pool);
-size_t __get_max_size(void* mem_pool);
-size_t __get_total_size(void* mem_pool);
 void* __malloc(size_t size, void* mem_pool);
 void __free(void *ptr, void* mem_pool);
 void* __realloc(void *ptr, size_t new_size, void* mem_pool);
 void* __calloc(size_t nelem, size_t elem_size, void* mem_pool);
-
-#ifndef DONT_MAKE_WRAPPER
-
-#ifndef get_used_size
-#define get_used_size __get_used_size
-#endif
-
-#ifndef get_max_size
-#define get_max_size __get_used_size
-#endif
-
-#ifndef get_total_size
-#define get_total_size __get_used_size
-#endif
-
-#ifndef malloc
-#define malloc __malloc
-#endif
-
-#ifndef free
-#define free __free
-#endif
-
-#ifndef realloc
-#define realloc __realloc
-#endif
-
-#ifndef calloc
-#define calloc __calloc
-#endif
-
-#endif /* DONT_MAKE_WRAPPER */
 
 #endif /* ___MALLOC_H__ */

--- a/lib/core/include/_string.h
+++ b/lib/core/include/_string.h
@@ -1,6 +1,3 @@
-/**
- * Removing the dependency with standard C library
- */
 #ifndef ___STRING_H__
 #define ___STRING_H__
 
@@ -24,65 +21,5 @@ int __strncmp(const char* s, const char* d, size_t size);
 char* __strdup(const char* source);
 long int __strtol(const char *nptr, char **endptr, int base);
 long long int __strtoll(const char *nptr, char **endptr, int base);
-
-#ifndef DONT_MAKE_WRAPPER
-
-#ifndef memset
-# define memset __memset
-#endif
-
-#ifndef memcpy
-# define memcpy __memcpy
-#endif
-
-#ifndef memmove
-# define memmove __memmove
-#endif
-
-#ifndef memcmp
-# define memcmp __memcmp
-#endif
-
-#ifndef bzero
-# define bzero __bzero
-#endif
-
-#ifndef strlen
-# define strlen __strlen
-#endif
-
-#ifndef strstr
-# define strstr __strstr
-#endif
-
-#ifndef strchr
-# define strchr __strchr
-#endif
-
-#ifndef strrchr
-# define strrchr __strrchr
-#endif
-
-#ifndef strcmp
-# define strcmp __strcmp
-#endif
-
-#ifndef strncmp
-# define strncmp __strncmp
-#endif
-
-#ifndef strdup
-# define strdup __strdup
-#endif
-
-#ifndef strtol
-# define strtol __strtol
-#endif
-
-#ifndef strtoll
-# define strtoll __strtoll
-#endif
-
-#endif /* DONT_MAKE_WRAPPER */
 
 #endif /* ___STRING_H__ */

--- a/lib/core/src/_malloc.c
+++ b/lib/core/src/_malloc.c
@@ -1,88 +1,31 @@
-#include <limits.h>
-#include <malloc.h>
 #include <tlsf.h>
 
-size_t __get_used_size(void *mem_pool) {
-
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		return INT_MAX;
-#else
-		extern void* __malloc_pool;
-		return get_used_size(__malloc_pool);
-#endif
-	} else
-		return get_used_size(mem_pool);
-}
-
-size_t __get_max_size(void* mem_pool) {
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		return INT_MAX;
-#else
-		extern void* __malloc_pool;
-		return get_max_size(__malloc_pool);
-#endif
-	} else
-		return get_max_size(mem_pool);
-}
-
-size_t __get_total_size(void* mem_pool) {
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		return INT_MAX;
-#else
-		extern void* __malloc_pool;
-		return get_total_size(__malloc_pool);
-#endif
-	} else
-		return get_total_size(mem_pool);
-}
+extern void* __malloc_pool;
 
 void* __malloc(size_t size, void* mem_pool) {
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		return malloc(size);
-#else
-		extern void* __malloc_pool;
+	if(!mem_pool)
 		return malloc_ex(size, __malloc_pool);
-#endif
-	} else
+	else 
 		return malloc_ex(size, mem_pool);
 }
 
-void __free(void *ptr, void* mem_pool) {
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		free(ptr);
-#else
-		extern void* __malloc_pool;
+void __free(void *ptr, void* mem_pool) { 
+	if(!mem_pool) 
 		free_ex(ptr, __malloc_pool);
-#endif
-	} else
+	else
 		free_ex(ptr, mem_pool);
 }
 
 void* __realloc(void *ptr, size_t new_size, void* mem_pool) {
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		return realloc(ptr, new_size);
-#else
-		extern void* __malloc_pool;
+	if(!mem_pool)
 		return realloc_ex(ptr, new_size, __malloc_pool);
-#endif
-	} else
+	else
 		return realloc_ex(ptr, new_size, mem_pool);
 }
 
 void* __calloc(size_t nelem, size_t elem_size, void* mem_pool) {
-	if(!mem_pool) {
-#ifdef LINUX /*LINUX*/
-		return calloc(nelem, elem_size);
-#else
-		extern void* __malloc_pool;
+	if(!mem_pool) 
 		return calloc_ex(nelem, elem_size, __malloc_pool);
-#endif
-	} else
+	else
 		return calloc_ex(nelem, elem_size, mem_pool);
 }

--- a/lib/core/src/_string.c
+++ b/lib/core/src/_string.c
@@ -1,4 +1,4 @@
-#include <_string.h>
+#include <string.h>
 #include <stdint.h>
 #include <malloc.h>
 #include <stdio.h>

--- a/lib/core/src/arp.c
+++ b/lib/core/src/arp.c
@@ -1,7 +1,5 @@
 #include <timer.h>
-#define DONT_MAKE_WRAPPER
 #include <_malloc.h>
-#undef DONT_MAKE_WRAPPER
 #include <net/interface.h>
 #include <net/ether.h>
 #include <net/arp.h>

--- a/lib/core/src/cmd.c
+++ b/lib/core/src/cmd.c
@@ -1,5 +1,5 @@
 #include <stdbool.h>
-#include <_string.h>
+#include <string.h>
 #include <malloc.h>
 #include <util/cmd.h>
 #include <util/map.h>

--- a/lib/core/src/fio.c
+++ b/lib/core/src/fio.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 #include <util/fifo.h>
-#include <tlsf.h>
+#include <_malloc.h>
 #include <fio.h>
 
 FIO* fio_create(void* pool) {
-	FIO* fio = malloc_ex(sizeof(FIO), pool);
+	FIO* fio = __malloc(sizeof(FIO), pool);
 	if(!fio) {
 		printf("FIO malloc error\n");
 		return NULL;
@@ -13,7 +13,7 @@ FIO* fio_create(void* pool) {
 	fio->input_buffer = fifo_create(FIO_INPUT_BUFFER_SIZE, pool);
 	if(!fio->input_buffer) {
 		printf("fifo creation error\n");
-		free_ex(fio, pool);
+		__free(fio, pool);
 		return NULL;
 	}
 
@@ -21,7 +21,7 @@ FIO* fio_create(void* pool) {
 	if(!fio->output_buffer) {
 		printf("fifo creation error\n");
 		fifo_destroy(fio->input_buffer);
-		free_ex(fio, pool);
+		__free(fio, pool);
 		return NULL;
 	}
 

--- a/lib/core/src/gmalloc.c
+++ b/lib/core/src/gmalloc.c
@@ -3,20 +3,21 @@
 #include <_malloc.h>
 #include <gmalloc.h>
 
+/* These functions could be replaced with kernel implemtation with strong symbols */
 void* __gmalloc_pool;
 
-void *gmalloc(size_t size) {
+void* __attribute__((weak)) gmalloc(size_t size) {
 	return __malloc(size, __gmalloc_pool);
 }
 
-void gfree(void *ptr) {
+void __attribute__((weak)) gfree(void *ptr) {
 	__free(ptr, __gmalloc_pool);
 }
 
-void *gcalloc(size_t nmemb, size_t size) {
+void* __attribute__((weak)) gcalloc(size_t nmemb, size_t size) {
 	return __calloc(nmemb, size, __gmalloc_pool);
 }
 
-void *grealloc(void *ptr, size_t size) {
+void* __attribute__((weak)) grealloc(void *ptr, size_t size) {
 	return __realloc(ptr, size, __gmalloc_pool);
 }

--- a/lib/core/src/interface.c
+++ b/lib/core/src/interface.c
@@ -1,7 +1,5 @@
 #include <net/interface.h>
-#define DONT_MAKE_WRAPPER
 #include <_malloc.h>
-#undef DONT_MAKE_WRAPPER
 #include <string.h>
 
 IPv4Interface* interface_alloc(void* pool) {

--- a/lib/core/src/json.c
+++ b/lib/core/src/json.c
@@ -1,4 +1,4 @@
-#include <_string.h>
+#include <string.h>
 #include <malloc.h>
 #include <errno.h>
 #include <util/json.h>

--- a/lib/core/src/malloc.c
+++ b/lib/core/src/malloc.c
@@ -1,24 +1,24 @@
+#include <limits.h>
 #include <malloc.h>
+#include <stdio.h>
+#include <_malloc.h>
 
+/* These functions could be replaced with other C library implemtation with strong symbols */
 void* __malloc_pool;
 
-#ifndef LINUX
-#include <tlsf.h>
-
-void* malloc(size_t size) {
-	return malloc_ex(size, __malloc_pool);
+void* __attribute__((weak)) malloc(size_t size) {
+	return __malloc(size, __malloc_pool);
 }
 
-void free(void* ptr) {
-	free_ex(ptr, __malloc_pool);
+void __attribute__((weak)) free(void *ptr) { 
+	__free(ptr, __malloc_pool);
 }
 
-void* realloc(void* ptr, size_t size) {
-	return realloc_ex(ptr, size, __malloc_pool);
+void* __attribute__((weak)) realloc(void *ptr, size_t new_size) {
+	return __realloc(ptr, new_size, __malloc_pool);
 }
 
-void* calloc(size_t nmemb, size_t size) {
-	return calloc_ex(nmemb, size, __malloc_pool);
+void* __attribute__((weak)) calloc(size_t nelem, size_t elem_size) {
+	return __calloc(nelem, elem_size, __malloc_pool);
 }
 
-#endif /* LINUX */

--- a/lib/core/src/map.c
+++ b/lib/core/src/map.c
@@ -1,4 +1,4 @@
-#include <_string.h>
+#include <string.h>
 #include <_malloc.h>
 #include <util/map.h>
 

--- a/lib/core/src/md5.c
+++ b/lib/core/src/md5.c
@@ -5,7 +5,7 @@
  * http://nayuki.eigenstate.org/page/fast-md5-hash-implementation-in-x86-assembly
  */
 
-#include <_string.h>
+#include <string.h>
 #include <net/md5.h>
 
 void md5_compress(uint32_t *state, uint32_t *block);

--- a/lib/core/src/nic.c
+++ b/lib/core/src/nic.c
@@ -1,9 +1,10 @@
-#include <_string.h>
+#include <tlsf.h>
 #include <lock.h>
 #include <util/map.h>
 #include <net/nic.h>
 #include <net/interface.h>
 #include <errno.h>
+#include <string.h>
 #include <_malloc.h>
 
 int __nic_count;
@@ -125,15 +126,15 @@ inline bool nic_tryoutput(NIC* nic, Packet* packet) {
 }
 
 size_t nic_pool_used(NIC* nic) {
-	return __get_used_size(nic->pool);
+	return get_used_size(nic->pool);
 }
 
 size_t nic_pool_free(NIC* nic) {
-	return __get_total_size(nic->pool) - __get_used_size(nic->pool);
+	return get_total_size(nic->pool) - get_used_size(nic->pool);
 }
 
 size_t nic_pool_total(NIC* nic) {
-	return __get_total_size(nic->pool);
+	return get_total_size(nic->pool);
 }
 
 #define CONFIG_INIT					\

--- a/lib/core/src/ring.c
+++ b/lib/core/src/ring.c
@@ -1,4 +1,4 @@
-#include <_string.h>
+#include <string.h>
 #include <sys/types.h>
 #include <util/ring.h>
 

--- a/lib/core/src/set.c
+++ b/lib/core/src/set.c
@@ -1,4 +1,4 @@
-#include <_string.h>
+#include <string.h>
 #include <_malloc.h>
 #include <util/set.h>
 

--- a/lib/core/src/tftp.c
+++ b/lib/core/src/tftp.c
@@ -1,4 +1,4 @@
-#include <_string.h>
+#include <string.h>
 #include <malloc.h>
 #include <time.h>
 #include <net/nic.h>

--- a/lib/core/src/types.c
+++ b/lib/core/src/types.c
@@ -1,4 +1,5 @@
-#include <_string.h>
+#include <stdlib.h>
+#include <string.h>
 #include <stddef.h>
 #include "util/types.h"
 


### PR DESCRIPTION
* Before, PacketNgin kernel, applications separately have been used C
library by compilation flag. It's too complicate to use properly.
* Malloc, free, realloc, calloc in libcore changed to weak symbol which
can be overrided by other libraries. When user want to make
PacketNgin application, they could be overrided by newlib
implementation. In case of linux application, default C library(glibc)
implementation can overwrite it.
* _malloc.c, _malloc.h in libcore are left for wrapping TLSF's malloc_ex, free_ex,
calloc_ex, realloc_ex. It's due to the fact that kernel, and core libraries
depends on the API that allow to NULL parameter for memory pool.
* Also, gmalloc in libcore are modified to weak symbol to avoid misuse
in kernel. Since gmalloc implementation in libcore does not have
bmalloc, user application cannot use extended gmalloc pool.
* String related functions like __memset, __memcpy are left only for
PacketNgin kernel. Linux and PacketNgin application are just expected to
use standard C libary implemetation.