### PR TITLE
Malloc linking problem in linux fixed

### DIFF
--- a/lib/core/src/_malloc.c
+++ b/lib/core/src/_malloc.c
@@ -1,31 +1,47 @@
 #include <tlsf.h>
 
-extern void* __malloc_pool;
+void* __malloc_pool;
 
 void* __malloc(size_t size, void* mem_pool) {
+#ifdef LINUX
+	return malloc(size);
+#else
 	if(!mem_pool)
 		return malloc_ex(size, __malloc_pool);
 	else 
 		return malloc_ex(size, mem_pool);
+#endif
 }
 
 void __free(void *ptr, void* mem_pool) { 
+#ifdef LINUX
+	return free(ptr);
+#else
 	if(!mem_pool) 
 		free_ex(ptr, __malloc_pool);
 	else
 		free_ex(ptr, mem_pool);
+#endif
 }
 
 void* __realloc(void *ptr, size_t new_size, void* mem_pool) {
+#ifdef LINUX
+	return realloc(ptr, new_size);
+#else
 	if(!mem_pool)
 		return realloc_ex(ptr, new_size, __malloc_pool);
 	else
 		return realloc_ex(ptr, new_size, mem_pool);
+#endif
 }
 
 void* __calloc(size_t nelem, size_t elem_size, void* mem_pool) {
+#ifdef LINUX
+	return calloc(nelem, elem_size);
+#else
 	if(!mem_pool) 
 		return calloc_ex(nelem, elem_size, __malloc_pool);
 	else
 		return calloc_ex(nelem, elem_size, mem_pool);
+#endif
 }

--- a/lib/core/src/lock.c
+++ b/lib/core/src/lock.c
@@ -8,12 +8,12 @@ bool cmpxchg(uint8_t volatile* s1, uint8_t s2, uint8_t d);
 
 void lock_lock(uint8_t volatile* lock) {
 	do {
-		while(lock_trylock(lock));
+		while(!lock_trylock(lock));
 	} while(cmpxchg(lock, 0, 1));
 }
 
 bool lock_trylock(uint8_t volatile* lock) {
-	return *lock;
+	return !(*lock);
 }
 
 void lock_unlock(uint8_t volatile* lock) {

--- a/lib/core/src/malloc.c
+++ b/lib/core/src/malloc.c
@@ -3,22 +3,21 @@
 #include <stdio.h>
 #include <_malloc.h>
 
-/* These functions could be replaced with other C library implemtation with strong symbols */
-void* __malloc_pool;
+extern void* __malloc_pool;
 
-void* __attribute__((weak)) malloc(size_t size) {
+void* malloc(size_t size) {
 	return __malloc(size, __malloc_pool);
 }
 
-void __attribute__((weak)) free(void *ptr) { 
+void free(void *ptr) { 
 	__free(ptr, __malloc_pool);
 }
 
-void* __attribute__((weak)) realloc(void *ptr, size_t new_size) {
+void* realloc(void *ptr, size_t new_size) {
 	return __realloc(ptr, new_size, __malloc_pool);
 }
 
-void* __attribute__((weak)) calloc(size_t nelem, size_t elem_size) {
+void* calloc(size_t nelem, size_t elem_size) {
 	return __calloc(nelem, elem_size, __malloc_pool);
 }
 

--- a/lib/library.lua
+++ b/lib/library.lua
@@ -18,6 +18,8 @@ workspace "Kernel"
         location "core/build"
         includedirs { "core/include", "TLSF/src", "jsmn/", "../cmocka/include" }
         files { "core/**.asm", "core/**.S", "core/**.h", "core/**.c" }
+        -- Exclude test sources
+        removefiles { "core/test/*"} 
         -- Enable exntension instruction for SSE. Do not need stack protector 
         buildoptions { "-msse4.1 -fno-stack-protector" }
 
@@ -27,6 +29,8 @@ workspace "Kernel"
         location "core/build"
         includedirs { "core/include", "TLSF/src", "jsmn/", "../cmocka/include" }
         files { "core/**.asm", "core/**.S", "core/**.h", "core/**.c" }
+        -- Exclude test sources and standard C library functions
+        removefiles { "core/test/*", "core/src/malloc.c" }
         buildoptions { "-msse4.1 -fno-stack-protector" }
         -- Define "LINUX" to make core library for Linux OS
         defines { "LINUX" }


### PR DESCRIPTION
* There was misunderstanding of gcc attribute "weak". Weak symbol could be
override only when static library which have pair strong symbol linked. 
Dynamic library does not be affected.
* Newlib has been compiled on flag "MALLOC_PROVIED". So it does not use its
own implementation.
* Since glib is dynamically linked by default, we should exclude our own 
malloc implementation when we compiled libumpn. Symbols in dynamic libary does
not override pair weak symbol.