### PR TITLE
Use dcfldd instead of dd for faster copy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -33,5 +33,5 @@ fi
 
 echo "Copying PacketNgin RTOS image..."
 let "count = $count - 1"
-$(sudo dd if=system.img of=/dev/${devices[$count]} && sync)
+$(sudo dcfldd if=system.img of=/dev/${devices[$count]} conv=sync,noerror) 
 echo "Done"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,6 +15,7 @@
   * cmake
   * node.js
   * autoconf
+  * dcfldd
 
 * Disable automount-open
 gsettings set org.gnome.desktop.media-handling automount-open false


### PR DESCRIPTION
* Too much time spent to copy image now, so found to other utility for disk
cloning.
* It's about x2 faster compared to dd.