### PR TITLE
Broken core stdio dump message fixed

### DIFF
--- a/kernel/src/stdio.c
+++ b/kernel/src/stdio.c
@@ -166,7 +166,8 @@ void stdio_dump(int coreno, int fd, char* buffer, volatile size_t* head, volatil
 	char* dump_lines(char* h, char* e) {
 		char* t = strchrn(h, e, '\n');
 		while(t) {
-			t++;
+			// Skip newline and null charater
+			t += 2;
 			while(t - h > body_len) {
 				write1(header, header_len);
 				write1(h, body_len);


### PR DESCRIPTION
* Header message (Core 01 >) must be appeared first, but it does not correctly
worked.
* C string made by quotation mark (") is termiated by NULL. So we have to skip
two charatecter(newline and NULL) for next line string.