### PR TITLE
Manager Shell bug fixing

### DIFF
--- a/kernel/src/manager.c
+++ b/kernel/src/manager.c
@@ -155,8 +155,8 @@ static void vm_set_handler(RPC* rpc, VMSpec* vm, void* context, void(*callback)(
 	callback(rpc, false);
 }
 
-static void vm_delete_handler(RPC* rpc, uint32_t vmid, void* context, void(*callback)(RPC* rpc, bool result)) {
-	bool result = vm_delete(vmid);
+static void vm_destroy_handler(RPC* rpc, uint32_t vmid, void* context, void(*callback)(RPC* rpc, bool result)) {
+	bool result = vm_destroy(vmid);
 	callback(rpc, result);
 }
 
@@ -311,7 +311,7 @@ static err_t manager_accept(void* arg, struct tcp_pcb* pcb, err_t err) {
 	rpc_vm_create_handler(rpc, vm_create_handler, NULL);
 	rpc_vm_get_handler(rpc, vm_get_handler, NULL);
 	rpc_vm_set_handler(rpc, vm_set_handler, NULL);
-	rpc_vm_delete_handler(rpc, vm_delete_handler, NULL);
+	rpc_vm_destroy_handler(rpc, vm_destroy_handler, NULL);
 	rpc_vm_list_handler(rpc, vm_list_handler, NULL);
 	rpc_status_get_handler(rpc, status_get_handler, NULL);
 	rpc_status_set_handler(rpc, status_set_handler, pcb);

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -900,7 +900,7 @@ static int cmd_create(int argc, char** argv, void(*callback)(char* result, int e
 	return 0;
 }
 
-static int cmd_vm_delete(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
+static int cmd_vm_destroy(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
 	if(argc < 1) {
 		return CMD_STATUS_WRONG_NUMBER;
 	}
@@ -910,13 +910,13 @@ static int cmd_vm_delete(int argc, char** argv, void(*callback)(char* result, in
 	}
 
 	uint32_t vmid = parse_uint32(argv[1]);
-	bool ret = vm_delete(vmid);
+	bool ret = vm_destroy(vmid);
 
 	if(ret) {
-		printf("vm delete success");
+		printf("vm delete success\n");
 		callback("true", 0);
 	} else {
-		printf("vm delete fail");
+		printf("vm delete fail\n");
 		callback("false", -1);
 	}
 
@@ -1457,7 +1457,7 @@ Command commands[] = {
 		.name = "delete",
 		.desc = "Delete VM",
 		.args = "result: bool, vmid: uint32",
-		.func = cmd_vm_delete
+		.func = cmd_vm_destroy
 	},
 	{
 		.name = "list",

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -84,7 +84,8 @@ static int cmd_echo(int argc, char** argv, void(*callback)(char* result, int exi
 			cmd_result[pos++] = ' ';
 		}
 	}
-	callback(cmd_result, 0);
+	printf("%s\n", cmd_result);
+	callback("", 0);
 
 	return 0;
 }
@@ -190,7 +191,7 @@ static bool parse_addr(char* argv, uint32_t* address) {
 
 static int cmd_manager(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
 	if(manager_nic == NULL) {
-		printf("Can'nt found manager\n");
+		printf("Manager not found\n");
 		return -1;
 	}
 
@@ -215,7 +216,7 @@ static int cmd_manager(int argc, char** argv, void(*callback)(char* result, int 
 	}
 
 	if(!manager_nic) {
-		printf("Can'nt found manager\n");
+		printf("Manager not found\n");
 		return -1;
 	}
 
@@ -308,7 +309,7 @@ static int cmd_manager(int argc, char** argv, void(*callback)(char* result, int 
 		};
 
 		if(vnic_update(manager_nic, attrs)) {
-			printf("Can'nt found device\n");
+			printf("Device not found\n");
 			return -3;
 		}
 		manager_set_interface();
@@ -324,7 +325,8 @@ static int cmd_nic(int argc, char** argv, void(*callback)(char* result, int exit
 	extern Device* nic_devices[];
 	uint16_t nic_device_index = 0;
 
-	if(argc == 1 || (argc == 2 && !strcmp(argv[1], "list"))) {
+
+	if(argc == 1) {
 		for(int i = 0; i < NIC_MAX_DEVICE_COUNT; i++) {
 			Device* dev = nic_devices[i];
 			if(!dev) {
@@ -359,8 +361,52 @@ static int cmd_nic(int argc, char** argv, void(*callback)(char* result, int exit
 		}
 
 		return 0;
-	} else
+	} else if(argc == 2) {
+		for(int i = 0; i < NIC_MAX_DEVICE_COUNT; i++) {
+			Device* dev = nic_devices[i];
+			if(!dev) {
+				break;
+			}
+
+			NICPriv* nicpriv = dev->priv;
+			MapIterator iter;
+			map_iterator_init(&iter, nicpriv->nics);
+			while(map_iterator_has_next(&iter)) {
+				MapEntry* entry = map_iterator_next(&iter);
+				uint16_t port = (uint16_t)(uint64_t)entry->key;
+				uint16_t port_num = (port >> 12) & 0xf;
+				uint16_t vlan_id = port & 0xfff;
+
+				char name_buf[32];
+				if(!vlan_id) {
+					sprintf(name_buf, "eth%d", nic_device_index + port_num);
+				} else {
+					sprintf(name_buf, "eth%d.%d", nic_device_index + port_num, vlan_id);
+				}
+				
+				if(!strncmp(name_buf, argv[1], sizeof(argv[1]))) {
+					printf("%12s", name_buf);
+					printf("HWaddr %02x:%02x:%02x:%02x:%02x:%02x\n",
+							(nicpriv->mac[port_num] >> 40) & 0xff,
+							(nicpriv->mac[port_num] >> 32) & 0xff,
+							(nicpriv->mac[port_num] >> 24) & 0xff,
+							(nicpriv->mac[port_num] >> 16) & 0xff,
+							(nicpriv->mac[port_num] >> 8) & 0xff,
+							(nicpriv->mac[port_num] >> 0) & 0xff);
+					return 0;
+				} else
+					continue;
+			}
+			nic_device_index += nicpriv->port_count;
+		}
+		printf("Device not found\n");
+
+		return -3;
+
+	} else {
+		printf("Too many arguments\n");
 		return -1;
+	}
 }
 
 static int cmd_vnic(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
@@ -385,19 +431,19 @@ static int cmd_vnic(int argc, char** argv, void(*callback)(char* result, int exi
 				switch(i) {
 					case 0:
 						printf("B)");
-					break;
+						break;
 					case 1:
 						printf("KB)");
-					break;
+						break;
 					case 2:
 						printf("MB)");
-					break;
+						break;
 					case 3:
 						printf("GB)");
-					break;
+						break;
 					case 4:
 						printf("TB)");
-					break;
+						break;
 				}
 				return;
 			}
@@ -416,12 +462,12 @@ static int cmd_vnic(int argc, char** argv, void(*callback)(char* result, int exi
 
 			printf("%12s", name_buf);
 			printf("HWaddr %02x:%02x:%02x:%02x:%02x:%02x  ",
-				(vnic->mac >> 40) & 0xff,
-				(vnic->mac >> 32) & 0xff,
-				(vnic->mac >> 24) & 0xff,
-				(vnic->mac >> 16) & 0xff,
-				(vnic->mac >> 8) & 0xff, 
-				(vnic->mac >> 0) & 0xff);
+					(vnic->mac >> 40) & 0xff,
+					(vnic->mac >> 32) & 0xff,
+					(vnic->mac >> 24) & 0xff,
+					(vnic->mac >> 16) & 0xff,
+					(vnic->mac >> 8) & 0xff, 
+					(vnic->mac >> 0) & 0xff);
 
 			uint16_t port_num = vnic->port >> 12;
 			uint16_t vlan_id = vnic->port & 0xfff;
@@ -481,7 +527,7 @@ static int cmd_vlan(int argc, char** argv, void(*callback)(char* result, int exi
 		uint16_t port = 0;
 		Device* dev = nic_parse_index(argv[2], &port);
 		if(!dev) {
-			printf("Can'nt found Device\n");
+			printf("Device not found\n");
 			return -2;
 		}
 
@@ -505,11 +551,11 @@ static int cmd_vlan(int argc, char** argv, void(*callback)(char* result, int exi
 
 		Map* vnics = map_create(8, NULL, NULL, NULL);
 		if(!vnics) {
-			printf("Can'nt allocate vnic map\n");
+			printf("Cannot allocate vnic map\n");
 			return -4;
 		}
 		if(!map_put(nics, (void*)(uint64_t)port, vnics)) {
-			printf("Can'nt add VLAN");
+			printf("Cannot add VLAN");
 			map_destroy(vnics);
 			return -4;
 		}
@@ -532,7 +578,7 @@ static int cmd_vlan(int argc, char** argv, void(*callback)(char* result, int exi
 		}
 
 		if(!map_remove(((NICPriv*)dev->priv)->nics, (void*)(uint64_t)port)) {
-			printf("Can'nt remove VLAN\n");
+			printf("Cannot remove VLAN\n");
 			return -2;
 		}
 	} else
@@ -543,7 +589,7 @@ static int cmd_vlan(int argc, char** argv, void(*callback)(char* result, int exi
 
 static int cmd_version(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
 	printf("%d.%d.%d-%s\n", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO, VERSION_TAG);
-	
+
 	return 0;
 }
 
@@ -606,26 +652,26 @@ static int cmd_turbo(int argc, char** argv, void(*callback)(char* result, int ex
 
 static int cmd_reboot(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
 	asm volatile("cli");
-	
+
 	uint8_t code;
 	do {
 		code = port_in8(0x64);	// Keyboard Control
 		if(code & 0x01)
 			port_in8(0x60);	// Keyboard I/O
 	} while(code & 0x02);
-	
+
 	port_out8(0x64, 0xfe);	// Reset command
-	
+
 	while(1)
 		asm("hlt");
-	
+
 	return 0;
 }
 
 static int cmd_shutdown(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
 	printf("Shutting down\n");
 	acpi_shutdown();
-	
+
 	return 0;
 }
 
@@ -637,12 +683,12 @@ static uint64_t arping_event;
 static bool arping_timeout(void* context) {
 	if(arping_count <= 0)
 		return false;
-	
+
 	arping_time = timer_ns();
-	
+
 	printf("Reply timeout\n");
 	arping_count--;
-	
+
 	if(arping_count > 0) {
 		return true;
 	} else {
@@ -655,21 +701,21 @@ static int cmd_arping(int argc, char** argv, void(*callback)(char* result, int e
 	if(argc < 2) {
 		return CMD_STATUS_WRONG_NUMBER;
 	}
-	
+
 	if(!parse_addr(argv[1], &arping_addr)) {
 		printf("Address Wrong\n");
 		return -1;
 	}
-	
+
 	arping_time = timer_ns();
-	
+
 	arping_count = 1;
 	if(argc >= 4) {
 		if(strcmp(argv[2], "-c") == 0) {
 			arping_count = strtol(argv[3], NULL, 0);
 		}
 	}
-	
+
 	if(arp_request(manager_nic->nic, arping_addr, 0)) {
 		arping_event = event_timer_add(arping_timeout, NULL, 1000000, 1000000);
 	} else {
@@ -700,7 +746,7 @@ static int cmd_md5(int argc, char** argv, void(*callback)(char* result, int exit
 
 	if(!ret) {
 		sprintf(cmd_result, "(nil)");
-		printf("Can'nt md5 checksum\n");
+		printf("Can't md5 checksum\n");
 	} else {
 		char* p = (char*)cmd_result;
 		for(int i = 0; i < 16; i++, p += 2) {
@@ -709,8 +755,10 @@ static int cmd_md5(int argc, char** argv, void(*callback)(char* result, int exit
 		*p = '\0';
 	}
 
-	if(ret)
-		callback(cmd_result, 0);
+	if(ret) {
+		printf("%s\n", cmd_result);
+		callback("", 0);
+	}
 	return 0;
 }
 
@@ -726,7 +774,7 @@ static int cmd_create(int argc, char** argv, void(*callback)(char* result, int e
 	vm->nics = malloc(sizeof(NICSpec) * MAX_VNIC_COUNT);
 	vm->argc = 0;
 	vm->argv = malloc(sizeof(char*) * CMD_MAX_ARGC);
-	
+
 	for(int i = 1; i < argc; i++) {
 		if(strcmp(argv[i], "core:") == 0) {
 			i++;
@@ -734,7 +782,7 @@ static int cmd_create(int argc, char** argv, void(*callback)(char* result, int e
 				printf("core must be uint8\n");
 				return -1;
 			}
-			
+
 			vm->core_size = parse_uint8(argv[i]);
 		} else if(strcmp(argv[i], "memory:") == 0) {
 			i++;
@@ -742,7 +790,7 @@ static int cmd_create(int argc, char** argv, void(*callback)(char* result, int e
 				printf("memory must be uint32\n");
 				return -1;
 			}
-			
+
 			vm->memory_size = parse_uint32(argv[i]);
 		} else if(strcmp(argv[i], "storage:") == 0) {
 			i++;
@@ -750,11 +798,11 @@ static int cmd_create(int argc, char** argv, void(*callback)(char* result, int e
 				printf("storage must be uint32\n");
 				return -1;
 			}
-			
+
 			vm->storage_size = parse_uint32(argv[i]);
 		} else if(strcmp(argv[i], "nic:") == 0) {
 			i++;
-			
+
 			NICSpec* nic = &(vm->nics[vm->nic_count++]);
 			for( ; i < argc; i++) {
 				if(strcmp(argv[i], "mac:") == 0) {
@@ -834,13 +882,14 @@ static int cmd_create(int argc, char** argv, void(*callback)(char* result, int e
 			}
 		}
 	}
-	
+
 	uint32_t vmid = vm_create(vm);
 	if(vmid == 0) {
 		callback("false", -1);
 	} else {
 		sprintf(cmd_result, "%d", vmid);
-		callback(cmd_result, 0);
+		printf("%s\n", cmd_result);
+		callback("", 0);
 	}
 	for(int i = 0; i < vm->nic_count; i++) {
 		free(vm->nics[i].dev);
@@ -885,7 +934,8 @@ static int cmd_vm_list(int argc, char** argv, void(*callback)(char* result, int 
 		}
 	}
 
-	callback(cmd_result, 0);
+	printf("%s\n", cmd_result);
+	callback("", 0);
 	return 0;
 }
 
@@ -910,12 +960,13 @@ static int cmd_upload(int argc, char** argv, void(*callback)(char* result, int e
 		printf("Cannot open file: %s\n", file_name);
 		return 1;
 	}
-	
+
 	int offset = 0;
 	int len;
 	char buf[4096];
 	while((len = read(fd, buf, 4096)) > 0) {
 		if(vm_storage_write(vmid, buf, offset, len) != len) {
+			printf("upload fail : %s\n", file_name);
 			callback("false", -1);
 			return -1;
 		}
@@ -923,7 +974,8 @@ static int cmd_upload(int argc, char** argv, void(*callback)(char* result, int e
 		offset += len;
 	}
 
-	callback("true", 0);
+	printf("upload success : %d\n", vmid);
+	callback("", 0);
 	return 0;
 }
 
@@ -940,7 +992,7 @@ static int cmd_status_set(int argc, char** argv, void(*callback)(char* result, i
 		callback("invalid", -1);
 		return -1;
 	}
-	
+
 	uint32_t vmid = parse_uint32(argv[1]);
 	int status = 0;
 	if(strcmp(argv[0], "start") == 0) {
@@ -952,13 +1004,14 @@ static int cmd_status_set(int argc, char** argv, void(*callback)(char* result, i
 	} else if(strcmp(argv[0], "stop") == 0) {
 		status = VM_STATUS_STOP;
 	} else {
+		printf("%s: command not found\n", argv[0]);
 		callback("invalid", -1);
 		return -1;
 	}
-	
+
 	cmd_async = true;
 	vm_status_set(vmid, status, status_setted, callback);
-	
+
 	return 0;
 }
 
@@ -966,7 +1019,7 @@ static int cmd_status_get(int argc, char** argv, void(*callback)(char* result, i
 	if(argc < 2) {
 		return CMD_STATUS_WRONG_NUMBER;
 	}
-	
+
 	if(!is_uint32(argv[1])) {
 		return -1;
 	}
@@ -975,7 +1028,7 @@ static int cmd_status_get(int argc, char** argv, void(*callback)(char* result, i
 	extern Map* vms;
 	VM* vm = map_get(vms, (void*)(uint64_t)vmid);
 	if(!vm) {
-		printf("Can'nt found VM\n");
+		printf("Cannot found VM\n");
 		return -1;
 	}
 
@@ -1104,57 +1157,57 @@ static int cmd_mount(int argc, char** argv, void(*callback)(char* result, int ex
 }
 
 /*
-   * Basic display modes:
-   -mm		Produce machine-readable output (single -m for an obsolete format)
-   -t		Show bus tree
+ * Basic display modes:
+ -mm		Produce machine-readable output (single -m for an obsolete format)
+ -t		Show bus tree
 
-   * Display options:
-   -v		Be verbose (-vv for very verbose)
-   -k		Show kernel drivers handling each device
-   -x		Show hex-dump of the standard part of the config space
-   -xxx		Show hex-dump of the whole config space (dangerous; root only)
-   -xxxx		Show hex-dump of the 4096-byte extended config space (root only)
-   -b		Bus-centric view (addresses and IRQ's as seen by the bus)
-   -D		Always show domain numbers
+ * Display options:
+ -v		Be verbose (-vv for very verbose)
+ -k		Show kernel drivers handling each device
+ -x		Show hex-dump of the standard part of the config space
+ -xxx		Show hex-dump of the whole config space (dangerous; root only)
+ -xxxx		Show hex-dump of the 4096-byte extended config space (root only)
+ -b		Bus-centric view (addresses and IRQ's as seen by the bus)
+ -D		Always show domain numbers
 
-   * Resolving of device ID's to names:
-   -n		Show numeric ID's
-   -nn		Show both textual and numeric ID's (names & numbers)
-   -q		Query the PCI ID database for unknown ID's via DNS
-   -qq		As above, but re-query locally cached entries
-   -Q		Query the PCI ID database for all ID's via DNS
+ * Resolving of device ID's to names:
+ -n		Show numeric ID's
+ -nn		Show both textual and numeric ID's (names & numbers)
+ -q		Query the PCI ID database for unknown ID's via DNS
+ -qq		As above, but re-query locally cached entries
+ -Q		Query the PCI ID database for all ID's via DNS
 
-   * Selection of devices:
-   -s [[[[<domain>]:]<bus>]:][<slot>][.[<func>]]	Show only devices in selected slots
-   -d [<vendor>]:[<device>]			Show only devices with specified ID's
+ * Selection of devices:
+ -s [[[[<domain>]:]<bus>]:][<slot>][.[<func>]]	Show only devices in selected slots
+ -d [<vendor>]:[<device>]			Show only devices with specified ID's
 
-   * Other options:
-   -i <file>	Use specified ID database instead of /usr/share/misc/pci.ids.gz
-   -p <file>	Look up kernel modules in a given file instead of default modules.pcimap
-   -M		Enable `bus mapping' mode (dangerous; root only)
+ * Other options:
+ -i <file>	Use specified ID database instead of /usr/share/misc/pci.ids.gz
+ -p <file>	Look up kernel modules in a given file instead of default modules.pcimap
+ -M		Enable `bus mapping' mode (dangerous; root only)
 
-   * PCI access options:
-   -A <method>	Use the specified PCI access method (see `-A help' for a list)
-   -O <par>=<val>	Set PCI access parameter (see `-O help' for a list)
-   -G		Enable PCI access debugging
-   -H <mode>	Use direct hardware access (<mode> = 1 or 2)
-   -F <file>	Read PCI configuration dump from a given file
+ * PCI access options:
+ -A <method>	Use the specified PCI access method (see `-A help' for a list)
+ -O <par>=<val>	Set PCI access parameter (see `-O help' for a list)
+ -G		Enable PCI access debugging
+ -H <mode>	Use direct hardware access (<mode> = 1 or 2)
+ -F <file>	Read PCI configuration dump from a given file
  */
 static int cmd_lspci(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
-/* Basic display modes:*/
+	/* Basic display modes:*/
 	bool m = false;
 	bool t = false;
 
-/* Display options: */
+	/* Display options: */
 	bool v = false;		// show verbose
 	bool k = false;		// show drivers
 	uint8_t x = 0;	// hex-dump
 	bool b = false;		// kbus-centric view
 	bool D = false;	// show domain
 
-/* Resolving of device ID's to names: */
+	/* Resolving of device ID's to names: */
 	uint8_t n = 0;	// show numeric id's
-// 	uint8_t q;	// query the pci id databse
+	// 	uint8_t q;	// query the pci id databse
 	uint16_t s_bus = 0xffff;	// selected slots.
 	uint8_t s_slot = 0xff;
 	uint8_t s_function = 0xff;
@@ -1460,10 +1513,10 @@ Command commands[] = {
 		.name = "lspci",
 		.desc = "list all PCI Devices",
 		.args = "-t\tShow a tree of bus\n\
-			 -x\tShow hexadeciaml dump of PCI configuration data. (64Bytes)\n\
-			 -xxx\tShow hexademical dump of PCI configuration data. (256Bytes)\n\
-			 -xxxx\tShow hexademical dump of PCI configuration data. (4096Bytes)\n\
-			 -s\tSelect Device [<bus>:][<slot>][.<func>]\n",
+				 -x\tShow hexadeciaml dump of PCI configuration data. (64Bytes)\n\
+				 -xxx\tShow hexademical dump of PCI configuration data. (256Bytes)\n\
+				 -xxxx\tShow hexademical dump of PCI configuration data. (4096Bytes)\n\
+				 -s\tSelect Device [<bus>:][<slot>][.<func>]\n",
 		.func = cmd_lspci
 	},
 	{
@@ -1543,7 +1596,7 @@ void shell_callback() {
 		}
 		if(cmd_async)
 			break;
-		
+
 		ch = stdio_getchar();
 	}
 }
@@ -1551,7 +1604,7 @@ void shell_callback() {
 void shell_init() {
 	printf("\nPacketNgin ver %d.%d.%d-%s\n", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO, VERSION_TAG);
 	printf("# ");
-	
+
 	extern Device* device_stdin;
 	((CharIn*)device_stdin->driver)->set_callback(device_stdin->id, shell_callback);
 	cmd_async = false;
@@ -1561,39 +1614,39 @@ void shell_init() {
 bool shell_process(Packet* packet) {
 	if(arping_count == 0)
 		return false;
-	
+
 	Ether* ether = (Ether*)(packet->buffer + packet->start);
 	if(endian16(ether->type) != ETHER_TYPE_ARP)
 		return false;
-	
+
 	ARP* arp = (ARP*)ether->payload;
 	switch(endian16(arp->operation)) {
 		case 2: // Reply
 			;
 			uint64_t smac = endian48(arp->sha);
 			uint32_t sip = endian32(arp->spa);
-			
+
 			if(arping_addr == sip) {
 				uint32_t time = timer_ns() - arping_time;
 				uint32_t ms = time / 1000;
 				uint32_t ns = time - ms * 1000; 
-				
+
 				printf("Reply from %d.%d.%d.%d [%02x:%02x:%02x:%02x:%02x:%02x] %d.%dms\n",
-					(sip >> 24) & 0xff,
-					(sip >> 16) & 0xff,
-					(sip >> 8) & 0xff,
-					(sip >> 0) & 0xff,
-					(smac >> 40) & 0xff,
-					(smac >> 32) & 0xff,
-					(smac >> 24) & 0xff,
-					(smac >> 16) & 0xff,
-					(smac >> 8) & 0xff,
-					(smac >> 0) & 0xff,
-					ms, ns);
-				
+						(sip >> 24) & 0xff,
+						(sip >> 16) & 0xff,
+						(sip >> 8) & 0xff,
+						(sip >> 0) & 0xff,
+						(smac >> 40) & 0xff,
+						(smac >> 32) & 0xff,
+						(smac >> 24) & 0xff,
+						(smac >> 16) & 0xff,
+						(smac >> 8) & 0xff,
+						(smac >> 0) & 0xff,
+						ms, ns);
+
 				event_timer_remove(arping_event);
 				arping_count--;
-				
+
 				if(arping_count > 0) {
 					bool arping(void* context) {
 						arping_time = timer_ns();
@@ -1603,10 +1656,10 @@ bool shell_process(Packet* packet) {
 							arping_count = 0;
 							printf("Cannot send ARP packet\n");
 						}
-						
+
 						return false;
 					}
-					
+
 					event_timer_add(arping, NULL, 1000000, 1000000);
 				} else {
 					printf("Done\n");
@@ -1614,6 +1667,6 @@ bool shell_process(Packet* packet) {
 			}
 			break;
 	}
-	
+
 	return false;
 }

--- a/kernel/src/shell.c
+++ b/kernel/src/shell.c
@@ -913,10 +913,10 @@ static int cmd_vm_destroy(int argc, char** argv, void(*callback)(char* result, i
 	bool ret = vm_destroy(vmid);
 
 	if(ret) {
-		printf("vm delete success\n");
+		printf("Vm destroy success\n");
 		callback("true", 0);
 	} else {
-		printf("vm delete fail\n");
+		printf("Vm destroy fail\n");
 		callback("false", -1);
 	}
 
@@ -1454,8 +1454,8 @@ Command commands[] = {
 		.func = cmd_create 
 	},
 	{
-		.name = "delete",
-		.desc = "Delete VM",
+		.name = "destroy",
+		.desc = "Destroy VM",
 		.args = "result: bool, vmid: uint32",
 		.func = cmd_vm_destroy
 	},

--- a/kernel/src/vm.c
+++ b/kernel/src/vm.c
@@ -641,6 +641,12 @@ void vm_status_set(uint32_t vmid, int status, VM_STATUS_CALLBACK callback, void*
 	uint64_t event_type = 0;
 	switch(status) {
 		case VM_STATUS_START:
+			if(vm->used_size <= 0) {
+				printf("File size is 0. File is not uploaded on RTVM storage.\n");
+				callback(false, context);
+				//callback("File size is 0. File is not uploaded on RTVM storage.", context);
+				return;
+			}
 			if(vm->status != VM_STATUS_STOP) {
 				callback(false, context);
 				return;
@@ -770,10 +776,13 @@ ssize_t vm_storage_write(uint32_t vmid, void* buf, size_t offset, size_t size) {
 			_size = 0;
 		}
 
-		if(_size == 0)
+		if(_size == 0) {
+			vm->used_size = size;
 			break;
+		}
 		offset = 0;
 	}
+
 
 	if(_size != 0)
 		return -1;

--- a/kernel/src/vm.c
+++ b/kernel/src/vm.c
@@ -238,7 +238,7 @@ static void icc_stopped(ICC_Message* msg) {
 	printf("]\n");
 }
 
-static bool vm_destroy(VM* vm, int core) {
+static bool vm_delete(VM* vm, int core) {
 	bool is_destroy = true;
 	
 	if(core == -1) {
@@ -415,7 +415,7 @@ uint32_t vm_create(VMSpec* vm_spec) {
 	
 	if(j < vm->core_size) {
 		printf("Manager: Not enough core to allocate.\n");
-		vm_destroy(vm, -1);
+		vm_delete(vm, -1);
 		return 0;
 	}
 	
@@ -429,7 +429,7 @@ uint32_t vm_create(VMSpec* vm_spec) {
 		vm->memory.blocks[i] = bmalloc();
 		if(!vm->memory.blocks[i]) {
 			printf("Manager: Not enough memory to allocate.\n");
-			vm_destroy(vm, -1);
+			vm_delete(vm, -1);
 			return 0;
 		}
 	}
@@ -444,7 +444,7 @@ uint32_t vm_create(VMSpec* vm_spec) {
 		vm->storage.blocks[i] = bmalloc();
 		if(!vm->storage.blocks[i]) {
 			printf("Manager: Not enough storage to allocate.\n");
-			vm_destroy(vm, -1);
+			vm_delete(vm, -1);
 			return 0;
 		}
 	}
@@ -478,13 +478,13 @@ uint32_t vm_create(VMSpec* vm_spec) {
 		} else if(mac & NICSPEC_DEVICE_MAC) {
 			mac = vnic_get_device_mac(nics[i].dev);
 			if(vnic_contains(nics[i].dev, mac)) {
-				vm_destroy(vm, -1);
+				vm_delete(vm, -1);
 				return 0;
 			}
 		} else if(vnic_contains(nics[i].dev, mac)) {
 			printf("Manager: The mac address already in use: %012x.\n", mac);
 			map_remove(vms, (void*)(uint64_t)vmid);
-			vm_destroy(vm, -1);
+			vm_delete(vm, -1);
 			return 0;
 		}
 		
@@ -508,7 +508,7 @@ uint32_t vm_create(VMSpec* vm_spec) {
 		if(!vm->nics[i]) {
 			printf("Manager: Not enough VNIC to allocate: errno=%d.\n", errno);
 			map_remove(vms, (void*)(uint64_t)vmid);
-			vm_destroy(vm, -1);
+			vm_delete(vm, -1);
 			return 0;
 		}
 	}
@@ -549,7 +549,7 @@ uint32_t vm_create(VMSpec* vm_spec) {
 	return vmid;
 }
 
-bool vm_delete(uint32_t vmid) {
+bool vm_destroy(uint32_t vmid) {
 	VM* vm = map_get(vms, (void*)(uint64_t)vmid);
 	if(!vm)
 		return false;
@@ -570,7 +570,7 @@ bool vm_delete(uint32_t vmid) {
 	}
 	printf("]\n");
 	
-	vm_destroy(vm, -1);
+	vm_delete(vm, -1);
 	
 	return true;
 }

--- a/kernel/src/vm.h
+++ b/kernel/src/vm.h
@@ -40,7 +40,7 @@ typedef struct _VM {
 void vm_init();
 
 uint32_t vm_create(VMSpec* vm_spec);
-bool vm_delete(uint32_t vmid);
+bool vm_destroy(uint32_t vmid);
 int vm_count();
 bool vm_contains(uint32_t vmid);
 int vm_list(uint32_t* vmids, int size);

--- a/kernel/src/vm.h
+++ b/kernel/src/vm.h
@@ -26,6 +26,7 @@ typedef struct _VM {
 	uint8_t		cores[MP_MAX_CORE_COUNT];
 	Block		memory;
 	Block		storage;
+	int			used_size;			// temporary variable for checking upload.
 	int		    nic_count;
 	VNIC**		nics;	// gmalloc, ni_create
 	VFIO*		fio;

--- a/lib/core/include/control/rpc.h
+++ b/lib/core/include/control/rpc.h
@@ -70,10 +70,10 @@ struct _RPC {
 	void* vm_set_context;
 	void(*vm_set_handler)(RPC* rpc, VMSpec* vm, void* context, void(*callback)(RPC* rpc, bool result));
 	void* vm_set_handler_context;
-	bool(*vm_delete_callback)(bool result, void* context);
-	void* vm_delete_context;
-	void(*vm_delete_handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, bool result));
-	void* vm_delete_handler_context;
+	bool(*vm_destroy_callback)(bool result, void* context);
+	void* vm_destroy_context;
+	void(*vm_destroy_handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, bool result));
+	void* vm_destroy_handler_context;
 	bool(*vm_list_callback)(uint32_t* ids, uint16_t count, void* context);
 	void* vm_list_context;
 	void(*vm_list_handler)(RPC* rpc, int size, void* context, void(*callback)(RPC* rpc, uint32_t* ids, int size));
@@ -125,7 +125,7 @@ int rpc_hello(RPC* rpc, bool(*callback)(void* context), void* context);
 int rpc_vm_create(RPC* rpc, VMSpec* vm, bool(*callback)(uint32_t id, void* context), void* context);
 int rpc_vm_get(RPC* rpc, uint32_t id, bool(*callback)(VMSpec* vm, void* context), void* context);
 int rpc_vm_set(RPC* rpc, VMSpec* vm, bool(*callback)(bool result, void* context), void* context);
-int rpc_vm_delete(RPC* rpc, uint32_t id, bool(*callback)(bool result, void* context), void* context);
+int rpc_vm_destroy(RPC* rpc, uint32_t id, bool(*callback)(bool result, void* context), void* context);
 int rpc_vm_list(RPC* rpc, bool(*callback)(uint32_t* ids, uint16_t count, void* context), void* context);
 
 int rpc_status_get(RPC* rpc, uint32_t id, bool(*callback)(VMStatus status, void* context), void* context);
@@ -141,7 +141,7 @@ int rpc_stdio(RPC* rpc, uint32_t id, uint8_t thread_id, int fd, const char* str,
 void rpc_vm_create_handler(RPC* rpc, void(*handler)(RPC* rpc, VMSpec* vm, void* context, void(*callback)(RPC* rpc, uint32_t id)), void* context);
 void rpc_vm_get_handler(RPC* rpc, void(*handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, VMSpec* vm)), void* context);
 void rpc_vm_set_handler(RPC* rpc, void(*handler)(RPC* rpc, VMSpec* vm, void* context, void(*callback)(RPC* rpc, bool result)), void* context);
-void rpc_vm_delete_handler(RPC* rpc, void(*handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, bool result)), void* context);
+void rpc_vm_destroy_handler(RPC* rpc, void(*handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, bool result)), void* context);
 void rpc_vm_list_handler(RPC* rpc, void(*handler)(RPC* rpc, int size, void* context, void(*callback)(RPC* rpc, uint32_t* ids, int size)), void* context);
 
 void rpc_status_get_handler(RPC* rpc, void(*handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, VMStatus status)), void* context);

--- a/lib/core/src/cmd.c
+++ b/lib/core/src/cmd.c
@@ -45,14 +45,19 @@ int cmd_help(int argc, char** argv, void(*callback)(char* result, int exit_statu
 		}
 		printf("no help topics match '%s'\n", argv[1]);
 		if(callback != NULL)
-			callback("false", 0);
+			callback("", 0);
 
+		return 0;
+	} else if(argc >= 3) {
+		printf("Too much arguments");
+		if(callback != NULL)
+			callback("", 0);
 		return 0;
 	}
 
 end:
 	if(callback != NULL)
-		callback("true", 0);
+		callback("", 0);
 
         return 0;
 }

--- a/lib/core/src/cmd.c
+++ b/lib/core/src/cmd.c
@@ -45,20 +45,20 @@ int cmd_help(int argc, char** argv, void(*callback)(char* result, int exit_statu
 		}
 		printf("no help topics match '%s'\n", argv[1]);
 		if(callback != NULL)
-			callback("", 0);
+			callback("false", 0);
 
 		return 0;
 	} else if(argc >= 3) {
-		printf("Too much arguments");
+//		printf("Too much arguments");
 		if(callback != NULL)
-			callback("", 0);
+			printf("Wrong number of arguments");
+			callback("false", 0);
 		return 0;
 	}
 
 end:
 	if(callback != NULL)
-		callback("", 0);
-
+		callback("true", 0);
         return 0;
 }
 
@@ -195,8 +195,9 @@ int cmd_exec(char* line, void(*callback)(char* result, int exit_status)) {
 
 	cmd_parse_var(&argc, argv);
 
-	if(cmd_parse_arg(argc, argv) == false)
+	if(cmd_parse_arg(argc, argv) == false) {
 		return CMD_VARIABLE_NOT_FOUND;
+	}
 
 	Command* cmd = cmd_get(argc, argv);
 	int exit_status = CMD_STATUS_NOT_FOUND;

--- a/lib/core/src/rpc.c
+++ b/lib/core/src/rpc.c
@@ -580,40 +580,40 @@ static int vm_set_req_handler(RPC* rpc) {
 	RETURN();
 }
 
-// vm_delete client API
-int rpc_vm_delete(RPC* rpc, uint32_t id, bool(*callback)(bool result, void* context), void* context) {
+// vm_destroy client API
+int rpc_vm_destroy(RPC* rpc, uint32_t id, bool(*callback)(bool result, void* context), void* context) {
 	INIT();
 	
 	WRITE(write_uint16(rpc, RPC_TYPE_VM_DELETE_REQ));
 	WRITE(write_uint32(rpc, id));
 	
-	rpc->vm_delete_callback = callback;
-	rpc->vm_delete_context = context;
+	rpc->vm_destroy_callback = callback;
+	rpc->vm_destroy_context = context;
 	
 	RETURN();
 }
 
-static int vm_delete_res_handler(RPC* rpc) {
+static int vm_destroy_res_handler(RPC* rpc) {
 	INIT();
 	
 	bool result = false;
 	READ(read_bool(rpc, &result));
 	
-	if(rpc->vm_delete_callback && !rpc->vm_delete_callback(result, rpc->vm_delete_context)) {
-		rpc->vm_delete_callback = NULL;
-		rpc->vm_delete_context = NULL;
+	if(rpc->vm_destroy_callback && !rpc->vm_destroy_callback(result, rpc->vm_destroy_context)) {
+		rpc->vm_destroy_callback = NULL;
+		rpc->vm_destroy_context = NULL;
 	}
 	
 	RETURN();
 }
 
-// vm_delete server API
-void rpc_vm_delete_handler(RPC* rpc, void(*handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, bool result)), void* context) {
-	rpc->vm_delete_handler = handler;
-	rpc->vm_delete_handler_context = context;
+// vm_destroy server API
+void rpc_vm_destroy_handler(RPC* rpc, void(*handler)(RPC* rpc, uint32_t id, void* context, void(*callback)(RPC* rpc, bool result)), void* context) {
+	rpc->vm_destroy_handler = handler;
+	rpc->vm_destroy_handler_context = context;
 }
 
-static void vm_delete_handler_callback(RPC* rpc, bool result) {
+static void vm_destroy_handler_callback(RPC* rpc, bool result) {
 	INIT2();
 	
 	WRITE2(write_uint16(rpc, RPC_TYPE_VM_DELETE_RES));
@@ -622,16 +622,16 @@ static void vm_delete_handler_callback(RPC* rpc, bool result) {
 	RETURN2();
 }
 
-static int vm_delete_req_handler(RPC* rpc) {
+static int vm_destroy_req_handler(RPC* rpc) {
 	INIT();
 	
 	uint32_t id;
 	READ(read_uint32(rpc, &id));
 	
-	if(rpc->vm_delete_handler) {
-		rpc->vm_delete_handler(rpc, id, rpc->vm_delete_handler_context, vm_delete_handler_callback);
+	if(rpc->vm_destroy_handler) {
+		rpc->vm_destroy_handler(rpc, id, rpc->vm_destroy_handler_context, vm_destroy_handler_callback);
 	} else {
-		vm_delete_handler_callback(rpc, false);
+		vm_destroy_handler_callback(rpc, false);
 	}
 	
 	RETURN();
@@ -1146,8 +1146,8 @@ static Handler handlers[] = {
 	vm_get_res_handler,
 	vm_set_req_handler,
 	vm_set_res_handler,
-	vm_delete_req_handler,
-	vm_delete_res_handler,
+	vm_destroy_req_handler,
+	vm_destroy_res_handler,
 	vm_list_req_handler,
 	vm_list_res_handler,
 	status_get_req_handler,

--- a/lib/core/src/test/md5.c
+++ b/lib/core/src/test/md5.c
@@ -1,3 +1,4 @@
+/*
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -13,10 +14,11 @@
 
 #define ENTRY_CNT		14	//random value
 #define MSG_SIZE		128	//random value
-
+*/
 /**
  * This function uses openssl library for comparing hash return values.
  */
+/*
 static const char* test_message[ENTRY_CNT] = { 
 	"didfdfkfjalkdfkaldfjldjfkldsfklasjlkfajdskljdklafjdklfjkldajfkldfjdvf", 
 	"d41d8ruvyh5",
@@ -95,3 +97,5 @@ int main(void) {
 	};
 	return cmocka_run_group_tests(UnitTest, NULL, NULL);
 }
+
+*/

--- a/lib/core/src/test/rpc.c
+++ b/lib/core/src/test/rpc.c
@@ -384,7 +384,7 @@ static void rpc_vm_set_func() {
 	pthread_join(tcp_server, (void**)&status);
 }
 
-static void rpc_vm_delete_func() {
+static void rpc_vm_destroy_func() {
 	server_open = 0;
 	int port = 1029;
 	pthread_t tcp_server;
@@ -399,7 +399,7 @@ static void rpc_vm_delete_func() {
 
 	RPC* rpc = rpc_open(ip, port, 1);
 	
-	rpc_vm_delete(rpc, 1, NULL, NULL);
+	rpc_vm_destroy(rpc, 1, NULL, NULL);
 
 	assert_int_equal(*(uint16_t*)(rpc->wbuf), RPC_TYPE_VM_DELETE_REQ);
 	assert_int_equal(*(uint32_t*)(rpc->wbuf + 2), 1);
@@ -665,7 +665,7 @@ static void rpc_vm_set_handler_func() {
 	pthread_join(tcp_server, (void**)&status);
 }
 
-static void rpc_vm_delete_handler_func() {
+static void rpc_vm_destroy_handler_func() {
 	server_open = 0;
 	int port = 1034;
 	pthread_t tcp_server;
@@ -685,10 +685,10 @@ static void rpc_vm_delete_handler_func() {
 	}
 
 	char* context = "Context";
-	rpc_vm_delete_handler(rpc, handler, (void*)context);	
+	rpc_vm_destroy_handler(rpc, handler, (void*)context);	
 
-	assert_int_equal(handler, rpc->vm_delete_handler);
-	assert_memory_equal(context, rpc->vm_delete_handler_context, strlen(context));
+	assert_int_equal(handler, rpc->vm_destroy_handler);
+	assert_memory_equal(context, rpc->vm_destroy_handler_context, strlen(context));
 
 	server_open = 1;
 
@@ -1056,7 +1056,7 @@ int main(void) {
 //		cmocka_unit_test(rpc_vm_create_func),
 //		cmocka_unit_test(rpc_vm_get_func),
 //		cmocka_unit_test(rpc_vm_set_func),
-//		cmocka_unit_test(rpc_vm_delete_func),
+//		cmocka_unit_test(rpc_vm_destroy_func),
 //		cmocka_unit_test(rpc_vm_list_func),
 //		cmocka_unit_test(rpc_status_get_func),
 //		cmocka_unit_test(rpc_storage_download_func),
@@ -1066,7 +1066,7 @@ int main(void) {
 //		cmocka_unit_test(rpc_vm_create_handler_func),
 //		cmocka_unit_test(rpc_vm_get_handler_func),
 //		cmocka_unit_test(rpc_vm_set_handler_func),
-//		cmocka_unit_test(rpc_vm_delete_handler_func),
+//		cmocka_unit_test(rpc_vm_destroy_handler_func),
 //		cmocka_unit_test(rpc_vm_list_handler_func),
 //		cmocka_unit_test(rpc_vm_get_handler_func),
 //		cmocka_unit_test(rpc_vm_set_handler_func),

--- a/tools/console/src/console.c
+++ b/tools/console/src/console.c
@@ -796,8 +796,8 @@ Command commands[] = {
 		.func = cmd_vm_create
 	},
 	{
-		.name = "delete",
-		.desc = "Delete VM",
+		.name = "destroy",
+		.desc = "Destroy VM",
 		.args = "result: bool, vmid: uint32",
 		.func = cmd_vm_destroy
 	},

--- a/tools/console/src/console.c
+++ b/tools/console/src/console.c
@@ -306,8 +306,8 @@ static int cmd_vm_create(int argc, char** argv, void(*callback)(char* result, in
 	return 0;
 }
 
-static int cmd_vm_delete(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
-	bool callback_vm_delete(bool result, void* context) {
+static int cmd_vm_destroy(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
+	bool callback_vm_destroy(bool result, void* context) {
 		void(*callback)(char* result, int exit_status) = context;
 
 		if(result)
@@ -329,7 +329,7 @@ static int cmd_vm_delete(int argc, char** argv, void(*callback)(char* result, in
 	
 	uint32_t vmid = parse_uint32(argv[1]);
 
-	rpc_vm_delete(rpc, vmid, callback_vm_delete, callback);
+	rpc_vm_destroy(rpc, vmid, callback_vm_destroy, callback);
 	sync_status = false;
 
 	return 0;
@@ -799,7 +799,7 @@ Command commands[] = {
 		.name = "delete",
 		.desc = "Delete VM",
 		.args = "result: bool, vmid: uint32",
-		.func = cmd_vm_delete
+		.func = cmd_vm_destroy
 	},
 	{
 		.name = "list",

--- a/tools/umpn/src/main.c
+++ b/tools/umpn/src/main.c
@@ -448,8 +448,8 @@ Command commands[] = {
 		.func = cmd_vm_create
 	},
 	{ 
-		.name = "delete",
-		.desc = "Delete Virtual Machine",
+		.name = "destroy",
+		.desc = "Destroy Virtual Machine",
 		.func = cmd_vm_destroy
 	},
 	{ 

--- a/tools/umpn/src/main.c
+++ b/tools/umpn/src/main.c
@@ -260,7 +260,7 @@ error:
 	return -2;
 }
 
-static int cmd_vm_delete(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
+static int cmd_vm_destroy(int argc, char** argv, void(*callback)(char* result, int exit_status)) {
 	if(vm == NULL) {
 		printf("Virtual Machine is not created\n");
 		return -1;
@@ -422,7 +422,7 @@ static int cmd_exit(int argc, char** argv, void(*callback)(char* result, int exi
 	if(!cmd_vm_stop(0, NULL, NULL))
 		return -1;
 
-	if(!cmd_vm_delete(0, NULL, NULL))
+	if(!cmd_vm_destroy(0, NULL, NULL))
 		return -2;
 
 	printf("Exit\n");
@@ -450,7 +450,7 @@ Command commands[] = {
 	{ 
 		.name = "delete",
 		.desc = "Delete Virtual Machine",
-		.func = cmd_vm_delete
+		.func = cmd_vm_destroy
 	},
 	{ 
 		.name = "status",


### PR DESCRIPTION
Some Shell command bugs is fixed.
* 'nic list' command is deleted.
* 'nic [interface]' command is added.
* If over 2 arguments into nic commands, print error message from now.
* About cmd_callback, delete 'print' function. so, add print messages before previous callback functions.
* If starting RTVM before uploading PacketNgin net app, the status of RTVM is changed from stop to start.
* This bug is fixed through adding used_size that checks whether the storage of RTVM is written or not to 'VM' type.
* argument bug & printing true/false is also fixed.