### PR TITLE
Fixing bug of us&ms_timer()

### DIFF
--- a/lib/core/src/timer.c
+++ b/lib/core/src/timer.c
@@ -188,7 +188,7 @@ uint64_t timer_us() {
 	if(clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
 		return (uint64_t)-1;
 
-	return (uint64_t)(ts.tv_nsec * 1000 + ts.tv_sec * 1000000);
+	return (uint64_t)(ts.tv_nsec / 1000 + ts.tv_sec * 1000000);
 
 #else /* LINUX */
 	/* (Current CPU Time Stamp Counter / CPU frequency per nano-seconds) */
@@ -202,7 +202,7 @@ uint64_t timer_ms() {
 	if(clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
 		return (uint64_t)-1;
 
-	return (uint64_t)(ts.tv_nsec * 1000000 + ts.tv_sec * 1000);
+	return (uint64_t)(ts.tv_nsec / 1000000 + ts.tv_sec * 1000);
 
 #else /* LINUX */
 	/* (Current CPU Time Stamp Counter / CPU frequency per nano-seconds) */


### PR DESCRIPTION
* ns / 1000 = us
* ns / 1000000 = ms