### PR TITLE
Mismatch function arguments in example code.

### DIFF
--- a/examples/arp/src/main.c
+++ b/examples/arp/src/main.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 
 	return 0;

--- a/examples/echo/src/main.c
+++ b/examples/echo/src/main.c
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 
 	return 0;

--- a/examples/echo2/src/main.c
+++ b/examples/echo2/src/main.c
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 
 	return 0;

--- a/examples/ethernet/src/main.c
+++ b/examples/ethernet/src/main.c
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 
 	return 0;

--- a/examples/icmp/src/main.c
+++ b/examples/icmp/src/main.c
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 
 	return 0;

--- a/examples/loadbalancer/src/main.c
+++ b/examples/loadbalancer/src/main.c
@@ -747,7 +747,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 	
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 	
 	return 0;

--- a/examples/shared/pn_app/src/main.c
+++ b/examples/shared/pn_app/src/main.c
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 
 	return 0;

--- a/examples/slowpath/src/main.c
+++ b/examples/slowpath/src/main.c
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
 	thread_barrior();
 	
 	if(thread_id() == 0) {
-		gdestroy(argc, argv);
+		gdestroy();
 	}
 	
 	return 0;


### PR DESCRIPTION
* In all example, gdestroy() was used as gdestroy(argc, argv).
* Remove arguments.