### PR TITLE
Update required packages to build kernel image

### DIFF
--- a/util.mk
+++ b/util.mk
@@ -5,7 +5,7 @@ prepare:
 	@echo "Prepare all requirement packages for PacketNgin build"
 	sudo apt-get install -y git nasm multiboot libcurl4-gnutls-dev qemu-kvm bridge-utils \
 		libc6-dev-i386 doxygen graphviz kpartx bison flex cmake nodejs autoconf dcfldd \
-		cmake
+		cmake linux-headers-$(shell uname -r) dosfstools
 all: run
 
 # Default running option is QEMU


### PR DESCRIPTION
* linux-headers-$VERSION is required to build kernel driver module.
* dosfstools is required for 'mkfs.vfat' command.
* Tested on Ubuntu 16.04.